### PR TITLE
configure close-ability 

### DIFF
--- a/flag-bearer-tests/benches/acquire.rs
+++ b/flag-bearer-tests/benches/acquire.rs
@@ -140,7 +140,7 @@ mod semaphore {
         }
 
         pub async fn acquire(&self) -> Permit<'_> {
-            Permit(self.0.acquire(1).await.unwrap_or_else(|x| match x {}))
+            Permit(self.0.acquire(1).await.unwrap_or_else(|x| x.never()))
         }
     }
 }

--- a/flag-bearer-tests/benches/acquire.rs
+++ b/flag-bearer-tests/benches/acquire.rs
@@ -18,14 +18,14 @@ fn main() {
     println!("flag_bearer[threads = {t}, permits = {slow}]:");
     let semaphore = semaphore::Semaphore::new(slow);
     let h = bench(t, rounds, iters, &semaphore, async |s| {
-        black_box(s.acquire().await.unwrap());
+        black_box(s.acquire().await);
     });
     print_results(h);
 
     println!("flag_bearer[threads = {t}, permits = {fast}]:");
     let semaphore = semaphore::Semaphore::new(fast);
     let h = bench(t, rounds, iters, &semaphore, async |s| {
-        black_box(s.acquire().await.unwrap());
+        black_box(s.acquire().await);
     });
     print_results(h);
 
@@ -45,7 +45,7 @@ fn main() {
 }
 
 fn print_results(h: Histogram<u64>) {
-    for q in [0.5, 0.75, 0.9, 0.99, 1.0] {
+    for q in [0.5, 0.75, 0.9, 0.99, 0.999] {
         println!(
             "\t{}'th percentile of data is {:?}",
             q * 100.0,
@@ -137,8 +137,8 @@ mod semaphore {
             Self(flag_bearer::Semaphore::new_fifo(SemaphoreCounter(count)))
         }
 
-        pub async fn acquire(&self) -> Option<Permit<'_>> {
-            Some(Permit(self.0.acquire(1).await.ok()?))
+        pub async fn acquire(&self) -> Permit<'_> {
+            Permit(self.0.acquire(1).await.unwrap_or_else(|x| match x {}))
         }
     }
 }

--- a/flag-bearer-tests/benches/acquire.rs
+++ b/flag-bearer-tests/benches/acquire.rs
@@ -114,6 +114,8 @@ mod semaphore {
         /// Number of permits that have been acquired
         type Permit = usize;
 
+        type Closeable = flag_bearer::Uncloseable;
+
         fn acquire(&mut self, params: Self::Params) -> Result<Self::Permit, Self::Params> {
             if params <= self.0 {
                 self.0 -= params;

--- a/flag-bearer-tests/benches/try_acquire.rs
+++ b/flag-bearer-tests/benches/try_acquire.rs
@@ -98,6 +98,8 @@ mod semaphore {
         /// Number of permits that have been acquired
         type Permit = usize;
 
+        type Closeable = flag_bearer::Uncloseable;
+
         fn acquire(&mut self, params: Self::Params) -> Result<Self::Permit, Self::Params> {
             if params <= self.0 {
                 self.0 -= params;

--- a/flag-bearer-tests/benches/try_acquire.rs
+++ b/flag-bearer-tests/benches/try_acquire.rs
@@ -29,7 +29,7 @@ fn main() {
 }
 
 fn print_results(h: Histogram<u64>) {
-    for q in [0.5, 0.75, 0.9, 0.99, 1.0] {
+    for q in [0.5, 0.75, 0.9, 0.99, 0.999] {
         println!(
             "\t{}'th percentile of data is {:?}",
             q * 100.0,

--- a/flag-bearer-tests/tests/aimd.rs
+++ b/flag-bearer-tests/tests/aimd.rs
@@ -65,6 +65,7 @@ impl AimdState {
 impl SemaphoreState for AimdState {
     type Params = ();
     type Permit = ();
+    type Closeable = flag_bearer::Uncloseable;
 
     fn acquire(&mut self, _: ()) -> Result<(), ()> {
         if self.acquired < self.state.limit {

--- a/flag-bearer-tests/tests/aimd.rs
+++ b/flag-bearer-tests/tests/aimd.rs
@@ -95,7 +95,7 @@ async fn check() {
 
     assert_eq!(sem.with_state(|s| s.available()), 10);
 
-    let permit1 = sem.acquire(()).await;
+    let permit1 = sem.acquire(()).await.unwrap_or_else(|x| match x {});
     assert_eq!(sem.with_state(|s| s.available()), 9);
 
     sem.with_state(|s| s.failure());
@@ -107,8 +107,8 @@ async fn check() {
     sem.with_state(|s| s.failure());
     assert_eq!(sem.with_state(|s| s.available()), 2);
 
-    let _permit2 = sem.acquire(()).await;
-    let _permit3 = sem.acquire(()).await;
+    let _permit2 = sem.acquire(()).await.unwrap_or_else(|x| match x {});
+    let _permit3 = sem.acquire(()).await.unwrap_or_else(|x| match x {});
     assert_eq!(sem.with_state(|s| s.available()), 0);
 
     tokio::time::timeout(Duration::from_millis(100), sem.acquire(()))

--- a/flag-bearer-tests/tests/aimd.rs
+++ b/flag-bearer-tests/tests/aimd.rs
@@ -96,7 +96,7 @@ async fn check() {
 
     assert_eq!(sem.with_state(|s| s.available()), 10);
 
-    let permit1 = sem.acquire(()).await.unwrap_or_else(|x| match x {});
+    let permit1 = sem.acquire(()).await.unwrap_or_else(|x| x.never());
     assert_eq!(sem.with_state(|s| s.available()), 9);
 
     sem.with_state(|s| s.failure());
@@ -108,8 +108,8 @@ async fn check() {
     sem.with_state(|s| s.failure());
     assert_eq!(sem.with_state(|s| s.available()), 2);
 
-    let _permit2 = sem.acquire(()).await.unwrap_or_else(|x| match x {});
-    let _permit3 = sem.acquire(()).await.unwrap_or_else(|x| match x {});
+    let _permit2 = sem.acquire(()).await.unwrap_or_else(|x| x.never());
+    let _permit3 = sem.acquire(()).await.unwrap_or_else(|x| x.never());
     assert_eq!(sem.with_state(|s| s.available()), 0);
 
     tokio::time::timeout(Duration::from_millis(100), sem.acquire(()))

--- a/flag-bearer-tests/tests/dyn.rs
+++ b/flag-bearer-tests/tests/dyn.rs
@@ -46,6 +46,6 @@ async fn trait_object() {
     let s2: Arc<Semaphore<dyn SemaphoreState<Params = (), Permit = (), Closeable = Uncloseable>>> =
         Arc::new(Semaphore::new_fifo(Counter(1)));
 
-    let _p1 = s1.acquire(()).await.unwrap_or_else(|x| match x {});
-    let _p2 = s2.acquire(()).await.unwrap_or_else(|x| match x {});
+    let _p1 = s1.acquire(()).await.unwrap_or_else(|x| x.never());
+    let _p2 = s2.acquire(()).await.unwrap_or_else(|x| x.never());
 }

--- a/flag-bearer-tests/tests/dyn.rs
+++ b/flag-bearer-tests/tests/dyn.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use flag_bearer::{Semaphore, SemaphoreState};
+use flag_bearer::{Semaphore, SemaphoreState, Uncloseable};
 
 #[derive(Debug)]
 struct Dummy;
@@ -8,6 +8,7 @@ struct Dummy;
 impl SemaphoreState for Dummy {
     type Params = ();
     type Permit = ();
+    type Closeable = Uncloseable;
 
     fn acquire(&mut self, _params: Self::Params) -> Result<Self::Permit, Self::Params> {
         Ok(())
@@ -22,6 +23,7 @@ struct Counter(u64);
 impl SemaphoreState for Counter {
     type Params = ();
     type Permit = ();
+    type Closeable = Uncloseable;
 
     fn acquire(&mut self, p: Self::Params) -> Result<Self::Permit, Self::Params> {
         let Some(n) = self.0.checked_sub(1) else {
@@ -38,10 +40,10 @@ impl SemaphoreState for Counter {
 
 #[tokio::test]
 async fn trait_object() {
-    let s1: Arc<Semaphore<dyn SemaphoreState<Params = (), Permit = ()>>> =
+    let s1: Arc<Semaphore<dyn SemaphoreState<Params = (), Permit = (), Closeable = Uncloseable>>> =
         Arc::new(Semaphore::new_fifo(Dummy));
 
-    let s2: Arc<Semaphore<dyn SemaphoreState<Params = (), Permit = ()>>> =
+    let s2: Arc<Semaphore<dyn SemaphoreState<Params = (), Permit = (), Closeable = Uncloseable>>> =
         Arc::new(Semaphore::new_fifo(Counter(1)));
 
     let _p1 = s1.acquire(()).await.unwrap_or_else(|x| match x {});

--- a/flag-bearer-tests/tests/dyn.rs
+++ b/flag-bearer-tests/tests/dyn.rs
@@ -44,6 +44,6 @@ async fn trait_object() {
     let s2: Arc<Semaphore<dyn SemaphoreState<Params = (), Permit = ()>>> =
         Arc::new(Semaphore::new_fifo(Counter(1)));
 
-    let _p1 = s1.acquire(()).await.unwrap();
-    let _p2 = s2.acquire(()).await.unwrap();
+    let _p1 = s1.acquire(()).await.unwrap_or_else(|x| match x {});
+    let _p2 = s2.acquire(()).await.unwrap_or_else(|x| match x {});
 }

--- a/flag-bearer-tests/tests/pool.rs
+++ b/flag-bearer-tests/tests/pool.rs
@@ -29,17 +29,17 @@ async fn pool() {
         s.objects.push(Conn(1));
     });
 
-    let mut conn1 = pool.acquire(()).await.unwrap();
+    let mut conn1 = pool.acquire(()).await.unwrap_or_else(|x| match x {});
     assert_eq!(conn1.permit().0, 1);
     conn1.permit_mut().0 = 11;
 
-    let mut conn0 = pool.acquire(()).await.unwrap();
+    let mut conn0 = pool.acquire(()).await.unwrap_or_else(|x| match x {});
     assert_eq!(conn0.permit().0, 0);
     conn0.permit_mut().0 = 10;
 
     drop(conn1);
     drop(conn0);
 
-    let conn0 = pool.acquire(()).await.unwrap();
+    let conn0 = pool.acquire(()).await.unwrap_or_else(|x| match x {});
     assert_eq!(conn0.permit().0, 10);
 }

--- a/flag-bearer-tests/tests/pool.rs
+++ b/flag-bearer-tests/tests/pool.rs
@@ -10,6 +10,7 @@ struct Pool {
 impl SemaphoreState for Pool {
     type Params = ();
     type Permit = Conn;
+    type Closeable = flag_bearer::Uncloseable;
 
     fn acquire(&mut self, params: Self::Params) -> Result<Self::Permit, Self::Params> {
         self.objects.pop().ok_or(params)

--- a/flag-bearer-tests/tests/pool.rs
+++ b/flag-bearer-tests/tests/pool.rs
@@ -30,17 +30,17 @@ async fn pool() {
         s.objects.push(Conn(1));
     });
 
-    let mut conn1 = pool.acquire(()).await.unwrap_or_else(|x| match x {});
+    let mut conn1 = pool.acquire(()).await.unwrap_or_else(|x| x.never());
     assert_eq!(conn1.permit().0, 1);
     conn1.permit_mut().0 = 11;
 
-    let mut conn0 = pool.acquire(()).await.unwrap_or_else(|x| match x {});
+    let mut conn0 = pool.acquire(()).await.unwrap_or_else(|x| x.never());
     assert_eq!(conn0.permit().0, 0);
     conn0.permit_mut().0 = 10;
 
     drop(conn1);
     drop(conn0);
 
-    let conn0 = pool.acquire(()).await.unwrap_or_else(|x| match x {});
+    let conn0 = pool.acquire(()).await.unwrap_or_else(|x| x.never());
     assert_eq!(conn0.permit().0, 10);
 }

--- a/flag-bearer-tests/tests/semaphore.rs
+++ b/flag-bearer-tests/tests/semaphore.rs
@@ -5,8 +5,6 @@ use std::{
 };
 
 mod semaphore {
-    use flag_bearer::Closeable;
-
     #[derive(Debug)]
     struct SemaphoreCounter(usize);
 
@@ -16,6 +14,8 @@ mod semaphore {
 
         /// Number of permits that have been acquired
         type Permit = usize;
+
+        type Closeable = flag_bearer::Closeable;
 
         fn acquire(&mut self, params: Self::Params) -> Result<Self::Permit, Self::Params> {
             if params <= self.0 {
@@ -31,8 +31,8 @@ mod semaphore {
         }
     }
 
-    pub struct Semaphore(flag_bearer::Semaphore<SemaphoreCounter, Closeable>);
-    pub struct Permit<'a>(flag_bearer::Permit<'a, SemaphoreCounter, Closeable>);
+    pub struct Semaphore(flag_bearer::Semaphore<SemaphoreCounter>);
+    pub struct Permit<'a>(flag_bearer::Permit<'a, SemaphoreCounter>);
 
     #[derive(Debug)]
     pub enum TryAcquireError {
@@ -44,9 +44,7 @@ mod semaphore {
         pub const MAX_PERMITS: usize = usize::MAX;
 
         pub fn new(count: usize) -> Self {
-            Self(flag_bearer::Semaphore::new_closeable_fifo(
-                SemaphoreCounter(count),
-            ))
+            Self(flag_bearer::Semaphore::new_fifo(SemaphoreCounter(count)))
         }
 
         pub fn close(&self) {

--- a/flag-bearer-tests/tests/semaphore.rs
+++ b/flag-bearer-tests/tests/semaphore.rs
@@ -5,6 +5,8 @@ use std::{
 };
 
 mod semaphore {
+    use flag_bearer::Closeable;
+
     #[derive(Debug)]
     struct SemaphoreCounter(usize);
 
@@ -29,8 +31,8 @@ mod semaphore {
         }
     }
 
-    pub struct Semaphore(flag_bearer::Semaphore<SemaphoreCounter>);
-    pub struct Permit<'a>(flag_bearer::Permit<'a, SemaphoreCounter>);
+    pub struct Semaphore(flag_bearer::Semaphore<SemaphoreCounter, Closeable>);
+    pub struct Permit<'a>(flag_bearer::Permit<'a, SemaphoreCounter, Closeable>);
 
     #[derive(Debug)]
     pub enum TryAcquireError {
@@ -42,7 +44,9 @@ mod semaphore {
         pub const MAX_PERMITS: usize = usize::MAX;
 
         pub fn new(count: usize) -> Self {
-            Self(flag_bearer::Semaphore::new_fifo(SemaphoreCounter(count)))
+            Self(flag_bearer::Semaphore::new_closeable_fifo(
+                SemaphoreCounter(count),
+            ))
         }
 
         pub fn close(&self) {

--- a/flag-bearer-tests/tests/semaphore_lifo.rs
+++ b/flag-bearer-tests/tests/semaphore_lifo.rs
@@ -15,6 +15,8 @@ mod semaphore {
         /// Number of permits that have been acquired
         type Permit = usize;
 
+        type Closeable = flag_bearer::Uncloseable;
+
         fn acquire(&mut self, params: Self::Params) -> Result<Self::Permit, Self::Params> {
             if params <= self.0 {
                 self.0 -= params;

--- a/flag-bearer-tests/tests/semaphore_lifo.rs
+++ b/flag-bearer-tests/tests/semaphore_lifo.rs
@@ -46,11 +46,15 @@ mod semaphore {
         }
 
         pub async fn acquire(&self) -> Option<Permit<'_>> {
-            Some(Permit(self.0.acquire(1).await.ok()?))
+            Some(Permit(
+                self.0.acquire(1).await.unwrap_or_else(|x| match x {}),
+            ))
         }
 
         pub async fn acquire_many(&self, n: usize) -> Option<Permit<'_>> {
-            Some(Permit(self.0.acquire(n).await.ok()?))
+            Some(Permit(
+                self.0.acquire(n).await.unwrap_or_else(|x| match x {}),
+            ))
         }
 
         pub fn try_acquire(&self) -> Result<Permit<'_>, TryAcquireError> {

--- a/flag-bearer-tests/tests/semaphore_lifo.rs
+++ b/flag-bearer-tests/tests/semaphore_lifo.rs
@@ -49,13 +49,13 @@ mod semaphore {
 
         pub async fn acquire(&self) -> Option<Permit<'_>> {
             Some(Permit(
-                self.0.acquire(1).await.unwrap_or_else(|x| match x {}),
+                self.0.acquire(1).await.unwrap_or_else(|x| x.never()),
             ))
         }
 
         pub async fn acquire_many(&self, n: usize) -> Option<Permit<'_>> {
             Some(Permit(
-                self.0.acquire(n).await.unwrap_or_else(|x| match x {}),
+                self.0.acquire(n).await.unwrap_or_else(|x| x.never()),
             ))
         }
 

--- a/flag-bearer/src/acquire.rs
+++ b/flag-bearer/src/acquire.rs
@@ -176,10 +176,9 @@ impl<S: SemaphoreState + ?Sized> Future for Acquire<'_, S> {
                 Err(TryAcquireError::NoPermits(params)) => {
                     let queue = match &mut state.queue {
                         Ok(queue) => queue,
-                        // unreachable?
-                        Err(closed) => {
-                            return Poll::Ready(Err(S::Closeable::from_closed(closed, params)));
-                        }
+                        // Safety: if the queue was closed, we would get a `Closed` error type.
+                        // It was not closed, thus it still isn't closed.
+                        Err(_closed) => unsafe { core::hint::unreachable_unchecked() },
                     };
 
                     // no permit or we are not the leader, so we register into the queue.

--- a/flag-bearer/src/lib.rs
+++ b/flag-bearer/src/lib.rs
@@ -96,7 +96,7 @@ use parking_lot::Mutex;
 use pin_list::PinList;
 
 mod acquire;
-pub use acquire::TryAcquireError;
+pub use acquire::{AcquireError, TryAcquireError};
 
 /// The trait defining how [`Semaphore`]s behave.
 pub trait SemaphoreState {


### PR DESCRIPTION
I added support for `close()` to have parity with tokio's Semaphore. But I almost never want to close semaphores. Since supporting closeable semaphores is strictly more work, it makes sense for me to have it be configurable.